### PR TITLE
Correct pthread_setschedparam usage errors.

### DIFF
--- a/ThirdParty/PSCommon/XnLib/Source/Linux/XnLinuxThreads.cpp
+++ b/ThirdParty/PSCommon/XnLib/Source/Linux/XnLinuxThreads.cpp
@@ -154,7 +154,7 @@ XN_C_API XnStatus xnOSSetThreadPriority(XN_THREAD_HANDLE ThreadHandle, XnThreadP
 		memset(&param, 0, sizeof(param));
 	
 #ifndef XN_PLATFORM_HAS_NO_SCHED_PARAM
-		param.__sched_priority = 5;
+		param.sched_priority = 5;
 #endif
 		nPolicy = SCHED_RR;
 	}
@@ -166,7 +166,7 @@ XN_C_API XnStatus xnOSSetThreadPriority(XN_THREAD_HANDLE ThreadHandle, XnThreadP
 	rc = pthread_setschedparam(*ThreadHandle, nPolicy, &param);
 	if (rc != 0)
 	{
-		xnLogWarning(XN_MASK_OS, "Failed to set thread priority (%d)", errno);
+		xnLogWarning(XN_MASK_OS, "Failed to set thread priority (%d)", rc);
 		return (XN_STATUS_OS_THREAD_SET_PRIORITY_FAILED);
 	}
 	


### PR DESCRIPTION
The documented name for the priority scheduling parameter is sched_priority (see, e.g. http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_setschedparam.html, http://www.kernel.org/doc/man-pages/online/pages/man3/pthread_setschedparam.3.html).

pthread_setschedparam reports the error code via the return value, not errno.
