### PR TITLE
Fixes for Building under Linux

### DIFF
--- a/Source/Tools/NiViewer/Makefile
+++ b/Source/Tools/NiViewer/Makefile
@@ -22,7 +22,7 @@ ifeq ("$(OSTYPE)","Darwin")
 	LDFLAGS += -framework OpenGL -framework GLUT
 else
 	CFLAGS += -DUNIX -DGLX_GLXEXT_LEGACY
-	USED_LIBS += glut GL rt
+	USED_LIBS += glut GL
 	LDFLAGS += -pthread
 endif
 

--- a/Source/Tools/NiViewer/Makefile
+++ b/Source/Tools/NiViewer/Makefile
@@ -22,7 +22,8 @@ ifeq ("$(OSTYPE)","Darwin")
 	LDFLAGS += -framework OpenGL -framework GLUT
 else
 	CFLAGS += -DUNIX -DGLX_GLXEXT_LEGACY
-	USED_LIBS += glut GL
+	USED_LIBS += glut GL rt
+	LDFLAGS += -pthread
 endif
 
 LIB_DIRS  += ../../../ThirdParty/PSCommon/XnLib/Bin/$(PLATFORM)-$(CFG)

--- a/ThirdParty/PSCommon/XnLib/Include/XnMath.h
+++ b/ThirdParty/PSCommon/XnLib/Include/XnMath.h
@@ -29,11 +29,7 @@ namespace xnl
 
 	namespace Math
 	{
-		template <class T>
-		XnBool IsZero(T value, T tolerance)
-		{
-			return Abs(value) < tolerance;
-		}
+		
 		inline XnInt32 Abs(XnInt32 i)
 		{
 			return abs(i);
@@ -53,6 +49,11 @@ namespace xnl
 		inline XnDouble Sqrt(XnDouble f)
 		{
 			return sqrt(f);
+		}
+		template <class T>
+		XnBool IsZero(T value, T tolerance)
+		{
+			return Abs(value) < tolerance;
 		}
 		template <class T>
 		T Min(T value1, T value2)


### PR DESCRIPTION
I had to make some changes in order to get OpenNI2 to build on Linux.

The IsZero function in the XnLib code had to moved below the definition of Abs because it depended on the Abs definition.

In the Makefile for NiViewer, I added -pthread -lrt to the linker flags to pull in the necessary libraries.
