### PR TITLE
Prototype of image registration support for Kinect driver.

### DIFF
--- a/Source/Drivers/Kinect/DepthKinectStream.h
+++ b/Source/Drivers/Kinect/DepthKinectStream.h
@@ -2,6 +2,7 @@
 #define _DEPTH_KINECT_STREAM_H_
 
 #include "BaseKinectStream.h"
+#include "XnArray.h"
 
 struct INuiSensor;
 namespace kinect_device {
@@ -22,6 +23,9 @@ public:
 	virtual void notifyAllProperties();
 
 private:
+	xnl::Array<USHORT> m_depthValuesBuffer;
+	xnl::Array<LONG> m_mappedCoordsBuffer;
+
 	void populateFrameImageMetadata(OniDriverFrame* pFrame, int dataUnitSize);
 	void copyDepthPixelsStraight(const NUI_DEPTH_IMAGE_PIXEL* source, int numPoints, OniDriverFrame* pFrame);
 	void copyDepthPixelsWithImageRegistration(const NUI_DEPTH_IMAGE_PIXEL* source, int numPoints, OniDriverFrame* pFrame);

--- a/Source/Drivers/Kinect/DepthKinectStream.h
+++ b/Source/Drivers/Kinect/DepthKinectStream.h
@@ -23,8 +23,8 @@ public:
 
 private:
 	void populateFrameImageMetadata(OniDriverFrame* pFrame, int dataUnitSize);
-	void copyDepthPixelsStraight(void* source, int numPoints, OniDriverFrame* pFrame);
-	void copyDepthPixelsWithImageRegistration(void* source, int numPoints, OniDriverFrame* pFrame);
+	void copyDepthPixelsStraight(const NUI_DEPTH_IMAGE_PIXEL* source, int numPoints, OniDriverFrame* pFrame);
+	void copyDepthPixelsWithImageRegistration(const NUI_DEPTH_IMAGE_PIXEL* source, int numPoints, OniDriverFrame* pFrame);
 };
 } // namespace kinect_device
 #endif //_DEPTH_KINECT_STREAM_H_

--- a/Source/Drivers/Kinect/DepthKinectStream.h
+++ b/Source/Drivers/Kinect/DepthKinectStream.h
@@ -21,6 +21,10 @@ public:
 
 	virtual void notifyAllProperties();
 
+private:
+	void populateFrameImageMetadata(OniDriverFrame* pFrame, int dataUnitSize);
+	void copyDepthPixelsStraight(void* source, int numPoints, OniDriverFrame* pFrame);
+	void copyDepthPixelsWithImageRegistration(void* source, int numPoints, OniDriverFrame* pFrame);
 };
 } // namespace kinect_device
 #endif //_DEPTH_KINECT_STREAM_H_

--- a/Source/Drivers/Kinect/KinectDevice.cpp
+++ b/Source/Drivers/Kinect/KinectDevice.cpp
@@ -181,3 +181,7 @@ OniStatus KinectDevice::tryManualTrigger()
 	return ONI_STATUS_NOT_IMPLEMENTED;
 }
 
+OniBool KinectDevice::isImageRegistrationModeSupported(OniImageRegistrationMode mode)
+{
+	return (mode == ONI_IMAGE_REGISTRATION_DEPTH_TO_COLOR || mode == ONI_IMAGE_REGISTRATION_OFF);
+}

--- a/Source/Drivers/Kinect/KinectDevice.cpp
+++ b/Source/Drivers/Kinect/KinectDevice.cpp
@@ -130,17 +130,45 @@ void kinect_device::KinectDevice::destroyStream(oni::driver::StreamBase* pStream
 
 OniStatus KinectDevice::setProperty(int propertyId, const void* data, int dataSize)
 {
+	switch (propertyId) {
+	case ONI_DEVICE_PROPERTY_IMAGE_REGISTRATION:
+		{
+			// FIXME data size validation
+			if (m_pDepthStream) {
+				OniImageRegistrationMode* pMode = (OniImageRegistrationMode*)data;
+				m_pDepthStream->setImageRegistrationMode(*pMode);
+				return ONI_STATUS_OK;
+			} else {
+				return ONI_STATUS_ERROR;
+			}
+		}
+	}
+
 	return ONI_STATUS_NOT_IMPLEMENTED;
 }
 
 OniStatus KinectDevice::getProperty(int propertyId, void* data, int* pDataSize)
 {
+	switch (propertyId) {
+	case ONI_DEVICE_PROPERTY_IMAGE_REGISTRATION:
+		{
+			// FIXME data size validation
+			if (m_pDepthStream) {
+				OniImageRegistrationMode* pMode = (OniImageRegistrationMode*)data;
+				*pMode = m_pDepthStream->getImageRegistrationMode();
+				return ONI_STATUS_OK;
+			} else {
+				return ONI_STATUS_ERROR;
+			}
+		}
+	}
+
 	return ONI_STATUS_NOT_IMPLEMENTED;
 }
 
 OniBool KinectDevice::isPropertySupported(int propertyId)
 {
-	return ONI_STATUS_NOT_IMPLEMENTED;
+	return (propertyId == ONI_DEVICE_PROPERTY_IMAGE_REGISTRATION);
 }
 
 OniBool KinectDevice::isCommandSupported(int commandId)

--- a/Source/Drivers/Kinect/KinectDevice.h
+++ b/Source/Drivers/Kinect/KinectDevice.h
@@ -28,6 +28,8 @@ public:
 	virtual OniBool isCommandSupported(int commandId) ;
 	virtual OniStatus tryManualTrigger();
 
+	virtual OniBool isImageRegistrationModeSupported(OniImageRegistrationMode mode);
+
 private:
 	INuiSensor * m_pNuiSensor;
 	KinectStreamImpl* m_pDepthStream;

--- a/Source/Drivers/Kinect/KinectStreamImpl.h
+++ b/Source/Drivers/Kinect/KinectStreamImpl.h
@@ -44,10 +44,16 @@ public:
 
 	OniStatus getAutoExposure(BOOL *val);
 	
+	OniImageRegistrationMode getImageRegistrationMode() const { return m_imageRegistrationMode; }
+
+	void setImageRegistrationMode(OniImageRegistrationMode mode) { m_imageRegistrationMode = mode; }
+
 	OniStatus convertDepthToColorCoordinates(oni::driver::StreamBase* colorStream, 
 								int depthX, int depthY, OniDepthPixel depthZ, int* pColorX, int* pColorY);
 
 	static NUI_IMAGE_RESOLUTION getNuiImagResolution(int resolutionX, int resolutionY);
+
+	INuiSensor* getNuiSensor() { return m_pNuiSensor; } // Need review: not sure if it is a good idea to expose this.
 	
 private:
 		
@@ -58,6 +64,9 @@ private:
 	static XN_THREAD_PROC threadFunc(XN_THREAD_PARAM pThreadParam);
 
 	xnl::List<BaseKinectStream*> m_streamList;
+
+	OniImageRegistrationMode m_imageRegistrationMode;
+
 	// Thread
 	INuiSensor* m_pNuiSensor;
 	OniSensorType m_sensorType;


### PR DESCRIPTION
Hi OpenNI folks,

I created a prototype of depth-to-color image registration for Kinect driver as well as a few code readability improvement. I hope this prototype could be helpful for the early support of this feature.

I had some applications that needed this feature, but I came to know OpenNI2 did not support it yet from the community forum (http://community.openni.org/openni/topics/how_can_i_align_with_kinect). I thought I could contribute by creating a prototype since I already achieved Kinect SDK - OpenNI 1 mapping including this feature in my previous work (http://code.google.com/p/kinect-mssdk-openni-bridge/). I just applied the same idea in this prototype.

I wrote this code based on my best guess about the necessary background including the design philosophy, the intended spec, the coding convention, etc., so it might be wrong or inconsistent. Please feel free to review and fix it. If you want me to fix it, I would be happy to do my best.

Thank you very much,
Tomoto
