### PR TITLE
Allow for initialization INI files to be located other than in the executable path

### DIFF
--- a/Include/OniCAPI.h
+++ b/Include/OniCAPI.h
@@ -29,7 +29,7 @@
 /******************************************** General APIs */
 
 /**  Initialize OpenNI2. Use ONI_API_VERSION as the version. */
-ONI_C_API OniStatus oniInitialize(int apiVersion);
+ONI_C_API OniStatus oniInitialize(int apiVersion, const char* iniFileParentDirectory);
 /**  Shutdown OpenNI2 */
 ONI_C_API void oniShutdown();
 

--- a/Include/OpenNI.h
+++ b/Include/OpenNI.h
@@ -1947,10 +1947,11 @@ public:
 	Initialize the library.
 	This will load all available drivers, and see which devices are available
 	It is forbidden to call any other method in OpenNI before calling @ref initialize().
+	@param iniFileParentDirectory The path the the parent directory containing the OpenNI ini configuration files.
 	*/
-	static Status initialize()
+	static Status initialize(const char* iniFileParentDirectory = NULL)
 	{
-		return (Status)oniInitialize(ONI_API_VERSION); // provide version of API, to make sure proper struct sizes are used
+		return (Status)oniInitialize(ONI_API_VERSION, iniFileParentDirectory); // provide version of API, to make sure proper struct sizes are used
 	}
 
 	/**

--- a/Source/Core/OniContext.h
+++ b/Source/Core/OniContext.h
@@ -57,7 +57,7 @@ public:
 	Context();
 	~Context();
 
-	OniStatus initialize();
+	OniStatus initialize(const char* iniFileParentDirectory = NULL);
 	void shutdown();
 
 	OniStatus registerDeviceConnectedCallback(OniDeviceInfoCallback handler, void* pCookie, OniCallbackHandle& handle);

--- a/Source/Core/OpenNI.cpp
+++ b/Source/Core/OpenNI.cpp
@@ -26,10 +26,10 @@
 
 oni::implementation::Context g_Context;
 
-ONI_C_API OniStatus oniInitialize(int /*apiVersion*/)
+ONI_C_API OniStatus oniInitialize(int /*apiVersion*/, const char* iniFileParentDirectory)
 {
 	g_Context.clearErrorLogger();
-	OniStatus rc = g_Context.initialize();
+	OniStatus rc = g_Context.initialize(iniFileParentDirectory);
 	return rc;
 }
 


### PR DESCRIPTION
This commit lets the configuration files OpenNI.ini etc. to be located in an arbitrary path. Say, for example, I'd want to put these in /etc/ or /local/etc or path/relative/to/executable...
