### PR TITLE
Compile issues on old GCC

### DIFF
--- a/Source/Drivers/PS1080/DDK/XnDeviceBase.h
+++ b/Source/Drivers/PS1080/DDK/XnDeviceBase.h
@@ -101,7 +101,7 @@ public:
 	virtual XnStatus UnregisterFromPropertyChange(const XnChar* Module, XnUInt32 propertyId, XnCallbackHandle hCallback);
 
 	typedef xnl::Event<XnNewStreamDataEventArgs> NewStreamDataEvent;
-	NewStreamDataEvent::EventInterface& OnNewStreamDataEvent() { return m_OnNewStreamDataEvent; }
+	NewStreamDataEvent/* ::EventInterface */& OnNewStreamDataEvent() { return m_OnNewStreamDataEvent; }
 
 	/**
 	* Finds a stream (a module which has the IS_STREAM property set to TRUE). 

--- a/Source/Drivers/PS1080/DDK/XnFrameBufferManager.h
+++ b/Source/Drivers/PS1080/DDK/XnFrameBufferManager.h
@@ -68,7 +68,7 @@ public:
 	} NewFrameEventArgs;
 
 	typedef xnl::Event<NewFrameEventArgs> NewFrameEvent;
-	NewFrameEvent::EventInterface& OnNewFrameEvent() { return m_NewFrameEvent; }
+	NewFrameEvent/* ::EventInterface */& OnNewFrameEvent() { return m_NewFrameEvent; }
 
 private:
 	XnOniFramePool* m_pBufferPool;

--- a/Source/Drivers/PS1080/DDK/XnOniFramePool.h
+++ b/Source/Drivers/PS1080/DDK/XnOniFramePool.h
@@ -41,8 +41,8 @@ typedef struct
 
 class XnOniFramePool : public xnl::Pool<OniFrame>
 {
-public:
-	XnOniFramePool() : Pool(true), m_frameSize(0)
+   public:
+  XnOniFramePool() : xnl::Pool<OniFrame>::Pool(true), m_frameSize(0)
 	{
 	}
 
@@ -58,7 +58,7 @@ public:
 		Lock();
 
 		// Try to release the frame.
-		XnStatus nRetVal = Pool::Release(pFrame);
+		XnStatus nRetVal = xnl::Pool<OniFrame>::Release(pFrame);
 		if (nRetVal == XN_STATUS_OK)
 		{
 			// Check if frame requires resize.

--- a/ThirdParty/PSCommon/BuildSystem/patch4sse2
+++ b/ThirdParty/PSCommon/BuildSystem/patch4sse2
@@ -1,0 +1,7 @@
+*** /dev/null
+--- /dev/null
+***************
+*** 5
+- 	SSE_GENERATION = 3
+--- 5 -----
++ 	SSE_GENERATION = 2


### PR DESCRIPTION
Hi,

I've modified compile error on old gcc (I'm using gcc 4.4.5).And some test codes run successfully with this branch of OpenNI2.

And I added patch4sse2.This changes the default version of sse. I could not find how to change sse version in command line option, so I made this patch. If there is more smart way to use sse2, please add some notes in OpenNI site.

Thanks
