### PR TITLE
Fix linker errors for x64

### DIFF
--- a/Source/Tools/NiViewer/Makefile
+++ b/Source/Tools/NiViewer/Makefile
@@ -22,7 +22,7 @@ ifeq ("$(OSTYPE)","Darwin")
 	LDFLAGS += -framework OpenGL -framework GLUT
 else
 	CFLAGS += -DUNIX -DGLX_GLXEXT_LEGACY
-	USED_LIBS += glut GL
+	USED_LIBS += glut GL pthread rt
 endif
 
 LIB_DIRS  += ../../../ThirdParty/PSCommon/XnLib/Bin/$(PLATFORM)-$(CFG)


### PR DESCRIPTION
These changes fix following linker errors (undefined references) for NiViewer when compiled on Linux x64.

make -C Source/Tools/NiViewer
make[1]: Entering directory `/home/andreynech/projects/xtion/OpenNI2/Source/Tools/NiViewer'
g++ -o ../../../Bin/x64-Release/NiViewer ./../../../Bin/Intermediate/x64-Release/NiViewer/Device.o ./../../../Bin/Intermediate/x64-Release/NiViewer/Draw.o ./../../../Bin/Intermediate/x64-Release/NiViewer/Keyboard.o ./../../../Bin/Intermediate/x64-Release/NiViewer/Menu.o ./../../../Bin/Intermediate/x64-Release/NiViewer/MouseInput.o ./../../../Bin/Intermediate/x64-Release/NiViewer/NiViewer.o ./../../../Bin/Intermediate/x64-Release/NiViewer/Capture.o -L../../../ThirdParty/PSCommon/XnLib/Bin/x64-Release -L../../../Bin/x64-Release -lglut -lGL -lOpenNI2 -lXnLib -Wl,-rpath ./
../../../ThirdParty/PSCommon/XnLib/Bin/x64-Release/libXnLib.a(XnLinuxTime.o):XnLinuxTime.cpp:function xnOSGetMonoTime: error: undefined reference to 'clock_gettime'
../../../ThirdParty/PSCommon/XnLib/Bin/x64-Release/libXnLib.a(XnLinuxMutex.o):XnLinuxMutex.cpp:function xnOSUnNamedMutexCreate(XnMutex*): error: undefined reference to 'pthread_mutexattr_init'
../../../ThirdParty/PSCommon/XnLib/Bin/x64-Release/libXnLib.a(XnLinuxMutex.o):XnLinuxMutex.cpp:function xnOSUnNamedMutexCreate(XnMutex*): error: undefined reference to 'pthread_mutexattr_settype'
../../../ThirdParty/PSCommon/XnLib/Bin/x64-Release/libXnLib.a(XnLinuxMutex.o):XnLinuxMutex.cpp:function xnOSUnNamedMutexCreate(XnMutex*): error: undefined reference to 'pthread_mutexattr_destroy'
../../../ThirdParty/PSCommon/XnLib/Bin/x64-Release/libXnLib.a(XnLinuxMutex.o):XnLinuxMutex.cpp:function xnOSLockMutex: error: undefined reference to 'pthread_mutex_timedlock'
collect2: error: ld returned 1 exit status
make[1]: *** [../../../Bin/x64-Release/NiViewer] Error 1
make[1]: Leaving directory`/home/andreynech/projects/xtion/OpenNI2/Source/Tools/NiViewer'
make: **\* [Source/Tools/NiViewer] Error 2
