### PR TITLE
Extended property support for Kinect Driver (on top of #32 Mirror Mode support)

### DIFF
--- a/Include/KinectProperties.h
+++ b/Include/KinectProperties.h
@@ -1,0 +1,104 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _KINECT_PROPERTIES_H_
+#define _KINECT_PROPERTIES_H_
+
+#include <OniCTypes.h>
+
+/* 
+ * private properties of Microsoft Kinect devices.
+ *
+ * @remarks 
+ * properties structure is 0x045eXXYY (045e = Microsoft's USB vendor ID)
+ * where XX is range and YY is code.
+ * range values:
+ * 00 - common stream properties
+ * 10 - depth stream properties
+ * 20 - color stream properties
+ * E0 - device commands
+ * F0 - device properties
+ */
+enum
+{
+	KINECT_PROPERTY_BASE = 0x045e0000,
+
+	/*******************************************************************/
+	/* Common stream properties (00-)                                  */
+	/*******************************************************************/
+
+	/*******************************************************************/
+	/* Depth stream properties (10-)                                   */
+	/*******************************************************************/
+
+	/** OniBool, set and get.
+	 * Maps to Near Mode in Kinect SDK.
+	 * Also maps to XN_STREAM_PROPERTY_CLOSE_RANGE in PS1080.h.
+	 */
+	KINECT_DEPTH_PROPERTY_CLOSE_RANGE = KINECT_PROPERTY_BASE + 0x1001,
+
+	/*******************************************************************/
+	/* Color stream properties (20-)                                   */
+	/*******************************************************************/
+
+	/*******************************************************************/
+	/* Device commands (E0-)                                           */
+	/*******************************************************************/
+
+	/*******************************************************************/
+	/* Device properties (F0-)                                         */
+	/*******************************************************************/
+
+	/* 3D sensing properties (F0-) */
+
+	/** OniBool, set and get.
+	 * Maps to !NuiGetForceInfraredEmitterOff in Kinect SDK.
+	 * Also maps to XN_MODULE_PROPERTY_EMITTER_STATE.
+	 */
+	KINECT_DEVICE_PROPERTY_EMITTER_STATE = KINECT_PROPERTY_BASE + 0xF001,
+
+	/* Non- 3D sensing bonus properties (F8) */
+
+	/** long, set and get.
+	 * Maps to NuiCameraElevationGetAngle and NuiCameraElevationSetAngle in Kinect SDK.
+	 */
+	KINECT_DEVICE_PROPERTY_CAMERA_ELEVATION = KINECT_PROPERTY_BASE + 0xF801,
+
+	/** KinectVector3f, get only.
+	 * Maps to NuiAccelerometerGetCurrentReading.
+	 */
+	KINECT_DEVICE_PROPERTY_ACCELEROMETER = KINECT_PROPERTY_BASE + 0xF802,
+
+	/** String, get only.
+	 * Maps to NuiAudioArrayId.
+	 * Useful to find the mic array on the sensor when developing audio-enabled applications.
+	 */
+	KINECT_DEVICE_PROPERTY_AUDIO_ARRAY_ID = KINECT_PROPERTY_BASE + 0xF803,
+
+};
+
+typedef struct
+{
+	float x;
+	float y;
+	float z;
+} KinectVector3f;
+
+#endif // _KINECT_PROPERTIES_H_

--- a/Source/Core/OpenNI.vcxproj
+++ b/Source/Core/OpenNI.vcxproj
@@ -186,6 +186,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\Include\Driver\OniDriverAPI.h" />
     <ClInclude Include="..\..\Include\Driver\OniDriverTypes.h" />
+    <ClInclude Include="..\..\Include\KinectProperties.h" />
     <ClInclude Include="..\..\Include\OniCEnums.h" />
     <ClInclude Include="..\..\Include\OniCProperties.h" />
     <ClInclude Include="..\..\Include\OniEnums.h" />

--- a/Source/Core/OpenNI.vcxproj.filters
+++ b/Source/Core/OpenNI.vcxproj.filters
@@ -91,6 +91,9 @@
     <ClInclude Include="OniSensor.h">
       <Filter>Header files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Include\KinectProperties.h">
+      <Filter>Header files\API</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header files">

--- a/Source/Drivers/Kinect/BaseKinectStream.cpp
+++ b/Source/Drivers/Kinect/BaseKinectStream.cpp
@@ -16,6 +16,7 @@ BaseKinectStream::BaseKinectStream(KinectStreamImpl* pStreamImpl):
 {
 	m_running = false;
 	m_cropping.enabled = FALSE;
+	m_mirroring = FALSE;
 	pStreamImpl->addStream(this);
 }
 
@@ -44,6 +45,7 @@ void BaseKinectStream::destroy()
 	m_pStreamImpl->removeStream(this);
 }
 
+// TODO: EXACT_PROP_SIZE_OR_XXX should be used for property size checking rather than copy-and-pasting
 OniStatus BaseKinectStream::getProperty(int propertyId, void* data, int* pDataSize)
 {
 	OniStatus status = ONI_STATUS_NOT_SUPPORTED;
@@ -58,6 +60,13 @@ OniStatus BaseKinectStream::getProperty(int propertyId, void* data, int* pDataSi
 		else
 		{
 			status = GetCropping((OniCropping*)data);
+		}
+		break;
+	case ONI_STREAM_PROPERTY_MIRRORING:
+		{
+			EXACT_PROP_SIZE_OR_RETURN(*pDataSize, OniBool);
+			*(OniBool*)data = m_mirroring;
+			status = ONI_STATUS_OK;
 		}
 		break;
 	case ONI_STREAM_PROPERTY_HORIZONTAL_FOV:
@@ -118,6 +127,12 @@ OniStatus BaseKinectStream::setProperty(int propertyId, const void* data, int da
 		}
 		status = SetCropping((OniCropping*)data);
 	}
+	else if (propertyId == ONI_STREAM_PROPERTY_MIRRORING)
+	{
+		EXACT_PROP_SIZE_OR_RETURN(dataSize, OniBool);
+		m_mirroring = *(OniBool*)data;
+		status = ONI_STATUS_OK;
+	}
 	else if (propertyId == ONI_STREAM_PROPERTY_VIDEO_MODE)
 	{
 		if (dataSize != sizeof(OniVideoMode))
@@ -136,6 +151,7 @@ OniBool BaseKinectStream::isPropertySupported(int propertyId)
 	switch (propertyId)
 	{
 	case ONI_STREAM_PROPERTY_CROPPING:
+	case ONI_STREAM_PROPERTY_MIRRORING:
 	case ONI_STREAM_PROPERTY_HORIZONTAL_FOV:
 	case ONI_STREAM_PROPERTY_VERTICAL_FOV:
 	case ONI_STREAM_PROPERTY_VIDEO_MODE:

--- a/Source/Drivers/Kinect/BaseKinectStream.h
+++ b/Source/Drivers/Kinect/BaseKinectStream.h
@@ -53,6 +53,7 @@ protected:
 	KinectStreamImpl *m_pStreamImpl;
 	OniVideoMode m_videoMode;
 	OniCropping m_cropping;
+	OniBool m_mirroring;
 	bool m_running;
 	
 private:
@@ -60,4 +61,17 @@ private:
 
 };
 } // namespace kinect_device
+
+// Macro to ensure the property size.
+// To be used in getProperty/setProperty implementation.
+// Borrowed from Drivers/PSLink/PrimeClientDefs.h and modified a bit.
+#define EXACT_PROP_SIZE_OR_DO(size, type) if ((size_t)(size) != sizeof(type))
+
+#define EXACT_PROP_SIZE_OR_RETURN(size, type) \
+	EXACT_PROP_SIZE_OR_DO(size, type) \
+	{ \
+		printf("Unexpected size: %d != %d\n", (size), sizeof(type)); /* TODO: Better to use log */ \
+		return ONI_STATUS_ERROR; \
+	}
+
 #endif //_BASE_KINECT_STREAM_H_

--- a/Source/Drivers/Kinect/ColorKinectStream.cpp
+++ b/Source/Drivers/Kinect/ColorKinectStream.cpp
@@ -38,83 +38,20 @@ OniStatus ColorKinectStream::start()
 void ColorKinectStream::frameReceived(NUI_IMAGE_FRAME& imageFrame, NUI_LOCKED_RECT &LockedRect)
 {
 	OniFrame* pFrame = getServices().acquireFrame();
+
 	if (m_videoMode.pixelFormat == ONI_PIXEL_FORMAT_RGB888)
 	{
-		struct Rgba { unsigned char b, g, r, a; };
-		struct Rgb { unsigned char r, g, b;    };
-		if (!m_cropping.enabled)
-		{
-			Rgba* data_in = reinterpret_cast<Rgba*>(LockedRect.pBits);
-			Rgb* data_out = reinterpret_cast<Rgb*>(pFrame->data);
-			pFrame->dataSize = m_videoMode.resolutionY * m_videoMode.resolutionX * 3;
-			Rgba * data_in_end = data_in + (m_videoMode.resolutionY * m_videoMode.resolutionX);
-			while (data_in < data_in_end)
-			{
-				data_out->b = data_in->b;
-				data_out->r = data_in->r;
-				data_out->g = data_in->g;
-				++data_in;
-				++data_out;
-			}
-			pFrame->stride = m_videoMode.resolutionX * 3;
-		}
-		else
-		{
-			Rgba* data_in = reinterpret_cast<Rgba*>(LockedRect.pBits);
-			Rgb* data_out = reinterpret_cast<Rgb*>(pFrame->data);
-			pFrame->dataSize = m_cropping.height * m_cropping.width * 3;
-			int cropX = m_cropping.originX;
-			int cropY = m_cropping.originY;
-			while (cropY < m_cropping.originY + m_cropping.height)
-			{
-				while (cropX < m_cropping.originX + m_cropping.width)
-				{
-					Rgba* iter = data_in + (cropX + m_videoMode.resolutionX * cropY);
-					unsigned char c = iter->b;
-					data_out->b = c;
-					data_out->r = iter->r;
-					data_out->g = iter->g;
-					++data_out;
-					++cropX;
-				}
-				++cropY;
-				cropX = m_cropping.originX;
-			}
-			pFrame->stride = m_cropping.width * 3;
-		}
+		copyFrameRGB888(pFrame, imageFrame, LockedRect);
+	}
+	else if (m_videoMode.pixelFormat == ONI_PIXEL_FORMAT_YUV422)
+	{
+		copyFrameYUV422(pFrame, imageFrame, LockedRect);
 	}
 	else
 	{
-		if (!m_cropping.enabled)
-		{
-			xnOSMemCopy(pFrame->data, LockedRect.pBits, LockedRect.size);
-			pFrame->dataSize = LockedRect.size;
-			pFrame->stride = m_videoMode.resolutionX * 2;
-		}
-		else
-		{
-			unsigned short* data_in = reinterpret_cast<unsigned short*>(LockedRect.pBits);
-			unsigned short* data_out = reinterpret_cast<unsigned short*>(pFrame->data);
-			pFrame->dataSize = m_cropping.height * m_cropping.width * 2;
-
-			int cropX = m_cropping.originX;
-			int cropY = m_cropping.originY;
-			while (cropY < m_cropping.originY + m_cropping.height)
-			{
-				while (cropX < m_cropping.originX + m_cropping.width)
-				{
-					unsigned short* iter = data_in + (cropX + m_videoMode.resolutionX * cropY);
-					*data_out = *iter;
-					++data_out;
-					++cropX;
-				}
-				cropY++;
-				cropX = m_cropping.originX;
-			}
-			pFrame->stride = m_cropping.width * 2;
-
-		}
+		XN_ASSERT(FALSE); // unsupported format. should not come here.
 	}
+
 	pFrame->videoMode.resolutionX = m_videoMode.resolutionX;
 	pFrame->videoMode.resolutionY = m_videoMode.resolutionY;
 	if (m_cropping.enabled)
@@ -140,6 +77,96 @@ void ColorKinectStream::frameReceived(NUI_IMAGE_FRAME& imageFrame, NUI_LOCKED_RE
 	pFrame->timestamp = imageFrame.liTimeStamp.QuadPart*1000;
 	raiseNewFrame(pFrame);
 	getServices().releaseFrame(pFrame);
+}
+
+void ColorKinectStream::copyFrameRGB888(OniFrame* pFrame, NUI_IMAGE_FRAME& imageFrame, NUI_LOCKED_RECT &LockedRect)
+{
+	struct Rgba { unsigned char b, g, r, a; };
+
+	struct RgbaToRgbPixelCopier
+	{
+		void operator()(const Rgba* const in, OniRGB888Pixel* const out)
+		{
+			out->r = in->r;
+			out->g = in->g;
+			out->b = in->b;
+		}
+	};
+
+	typedef LineCopier<Rgba, OniRGB888Pixel, RgbaToRgbPixelCopier, ForwardMover<Rgba> > ForwardLineCopier;
+	typedef RectCopier<Rgba, OniRGB888Pixel, RgbaToRgbPixelCopier, ForwardMover<Rgba>, ForwardMover<Rgba> > ForwardRectCopier;
+	typedef RectCopier<Rgba, OniRGB888Pixel, RgbaToRgbPixelCopier, BackwardMover<Rgba>, ForwardMover<Rgba> > MirrorRectCopier;
+
+	Rgba* in = reinterpret_cast<Rgba*>(LockedRect.pBits);
+	OniRGB888Pixel* out = reinterpret_cast<OniRGB888Pixel*>(pFrame->data);
+
+	FrameCopier<Rgba, OniRGB888Pixel, ForwardLineCopier, ForwardRectCopier, MirrorRectCopier> copyFrame;
+	copyFrame(in, out, pFrame, m_videoMode, m_cropping, m_mirroring);
+}
+
+void ColorKinectStream::copyFrameYUV422(OniFrame* pFrame, NUI_IMAGE_FRAME& imageFrame, NUI_LOCKED_RECT &LockedRect)
+{
+	// I YUV422, two pixels are packed into a 4-byte sequence.
+	// We need a little tricky mapping implementation for mirror mode.
+
+	OniYUV422DoublePixel* in = reinterpret_cast<OniYUV422DoublePixel*>(LockedRect.pBits);
+	OniYUV422DoublePixel* out = reinterpret_cast<OniYUV422DoublePixel*>(pFrame->data);
+
+	int resolutionXInPackets = m_videoMode.resolutionX / 2;
+
+	struct SwappedYUV422PixelCopier
+	{
+		void operator()(const OniYUV422DoublePixel* const in, OniYUV422DoublePixel* const out)
+		{
+			out->u = in->u;
+			out->y1 = in->y2;
+			out->v = in->v;
+			out->y2 = in->y1;
+		}
+	};
+
+	typedef RectCopier<OniYUV422DoublePixel, OniYUV422DoublePixel, PixelCopier<OniYUV422DoublePixel, OniYUV422DoublePixel>,
+		ForwardMover<OniYUV422DoublePixel>, ForwardMover<OniYUV422DoublePixel> > ForwardRectCopier;
+	typedef RectCopier<OniYUV422DoublePixel, OniYUV422DoublePixel, SwappedYUV422PixelCopier,
+		BackwardMover<OniYUV422DoublePixel>, ForwardMover<OniYUV422DoublePixel> > MirrorRectCopier;
+
+	if (!m_cropping.enabled)
+	{
+		pFrame->dataSize = LockedRect.size;
+		pFrame->stride = m_videoMode.resolutionX * 2;
+
+		if (!m_mirroring)
+		{
+			// optimized copy
+			xnOSMemCopy(pFrame->data, LockedRect.pBits, LockedRect.size);
+		} else {
+			MirrorRectCopier copyRect;
+			copyRect(in + resolutionXInPackets - 1, out,
+				resolutionXInPackets, resolutionXInPackets, m_videoMode.resolutionY);
+		}
+	}
+	else
+	{
+		int pixelCount = m_cropping.height * m_cropping.width;
+		pFrame->dataSize = pixelCount * 2;
+		pFrame->stride = m_cropping.width * 2;
+
+		int originXInPackets = m_cropping.originX / 2;
+		int copyWidthInPackets = m_cropping.width / 2;
+
+		if (!m_mirroring)
+		{
+			ForwardRectCopier copyRect;
+			OniYUV422DoublePixel* origin = in + m_cropping.originY * resolutionXInPackets + originXInPackets;
+			copyRect(origin, out, copyWidthInPackets, resolutionXInPackets, m_cropping.height);
+		}
+		else
+		{
+			MirrorRectCopier copyRect;
+			OniYUV422DoublePixel* origin = in + (m_cropping.originY+1) * resolutionXInPackets - originXInPackets - 1;
+			copyRect(origin, out, copyWidthInPackets, resolutionXInPackets, m_cropping.height);
+		}
+	}
 }
 
 OniStatus ColorKinectStream::getProperty(int propertyId, void* data, int* pDataSize)

--- a/Source/Drivers/Kinect/ColorKinectStream.h
+++ b/Source/Drivers/Kinect/ColorKinectStream.h
@@ -21,6 +21,10 @@ public:
 	virtual OniStatus setProperty(int propertyId, const void* data, int pDataSize);
 	
 	virtual OniBool isPropertySupported(int propertyId);
+
+private:
+	void copyFrameRGB888(OniFrame* pFrame, NUI_IMAGE_FRAME& imageFrame, NUI_LOCKED_RECT &LockedRect);
+	void copyFrameYUV422(OniFrame* pFrame, NUI_IMAGE_FRAME& imageFrame, NUI_LOCKED_RECT &LockedRect);
 };
 } // namespace kinect_device
 

--- a/Source/Drivers/Kinect/DepthKinectStream.cpp
+++ b/Source/Drivers/Kinect/DepthKinectStream.cpp
@@ -130,11 +130,11 @@ struct DepthMapper
 
 		for (unsigned int i = 0; i < numPoints; i++)
 		{
-			const unsigned int x = *mappedCoordsIter++ - minX;
+			const unsigned int x = transformX(*mappedCoordsIter++) - minX;
 			const unsigned int y = *mappedCoordsIter++ - minY;
 			if (x < width - 1 && y < height) {
 				const unsigned short d = filterReliableDepthValue((in+i)->depth);
-				OniDepthPixel* p = out + transformX(x) + y * width;
+				OniDepthPixel* p = out + x + y * width;
 				if (*p == 0 || *p > d) *p = d;
 				p++;
 				if (*p == 0 || *p > d) *p = d;
@@ -186,7 +186,7 @@ void DepthKinectStream::copyDepthPixelsWithImageRegistration(const NUI_DEPTH_IMA
 		};
 
 		DepthMapper<BackwardXTransformer> mapDepth;
-		mapDepth(source, target, m_mappedCoordsBuffer.GetData(), numPoints, pFrame, BackwardXTransformer(pFrame->width));
+		mapDepth(source, target, m_mappedCoordsBuffer.GetData(), numPoints, pFrame, BackwardXTransformer(pFrame->videoMode.resolutionX));
 	}
 
 	// FIXME: for preliminary benchmarking purpose

--- a/Source/Drivers/Kinect/DepthKinectStream.h
+++ b/Source/Drivers/Kinect/DepthKinectStream.h
@@ -18,6 +18,8 @@ public:
 	
 	virtual OniStatus getProperty(int propertyId, void* data, int* pDataSize);
 
+	virtual OniStatus setProperty(int propertyId, const void* data, int dataSize);
+
 	virtual OniBool isPropertySupported(int propertyId);
 
 	virtual void notifyAllProperties();
@@ -28,6 +30,9 @@ private:
 	void populateFrameImageMetadata(OniFrame* pFrame, int dataUnitSize);
 	void copyDepthPixelsStraight(const NUI_DEPTH_IMAGE_PIXEL* source, int numPoints, OniFrame* pFrame);
 	void copyDepthPixelsWithImageRegistration(const NUI_DEPTH_IMAGE_PIXEL* source, int numPoints, OniFrame* pFrame);
+
+	OniStatus setNearMode(OniBool value);
+	OniStatus getNearMode(OniBool* pValue);
 };
 } // namespace kinect_device
 #endif //_DEPTH_KINECT_STREAM_H_

--- a/Source/Drivers/Kinect/DepthKinectStream.h
+++ b/Source/Drivers/Kinect/DepthKinectStream.h
@@ -23,8 +23,7 @@ public:
 	virtual void notifyAllProperties();
 
 private:
-	xnl::Array<USHORT> m_depthValuesBuffer;
-	xnl::Array<LONG> m_mappedCoordsBuffer;
+	xnl::Array<int> m_mappedCoordsBuffer;
 
 	void populateFrameImageMetadata(OniFrame* pFrame, int dataUnitSize);
 	void copyDepthPixelsStraight(const NUI_DEPTH_IMAGE_PIXEL* source, int numPoints, OniFrame* pFrame);

--- a/Source/Drivers/Kinect/IRKinectStream.cpp
+++ b/Source/Drivers/Kinect/IRKinectStream.cpp
@@ -38,109 +38,73 @@ OniStatus IRKinectStream::start()
 void IRKinectStream::frameReceived(NUI_IMAGE_FRAME& imageFrame, NUI_LOCKED_RECT &LockedRect)
 {
 	OniFrame* pFrame = getServices().acquireFrame();
+
 	if (m_videoMode.pixelFormat == ONI_PIXEL_FORMAT_GRAY16)
 	{
-		unsigned short* data_in = reinterpret_cast<unsigned short*>(LockedRect.pBits);
-		unsigned short* data_out = reinterpret_cast<unsigned short*>(pFrame->data);
-		if (!m_cropping.enabled)
+		struct IRToGray16PixelCopier
 		{
-			unsigned short* data_in_end = data_in + (m_videoMode.resolutionY * m_videoMode.resolutionX);
-			while (data_in < data_in_end)
+			void operator()(const USHORT* const in, OniGrayscale16Pixel* const out)
 			{
-				unsigned short intensity = (*data_in)>> 6;
-				*data_out = intensity;
-				++data_in;
-				++data_out;
+				*out = (*in) >> 6;
 			}
-			pFrame->stride = m_videoMode.resolutionX * 2;
-		}
-		else
-		{
-			int cropY = m_cropping.originY;
-			while (cropY < m_cropping.originY + m_cropping.height)
-			{
-				int cropX = m_cropping.originX;
-				while (cropX < m_cropping.originX + m_cropping.width)
-				{
-					unsigned short *iter = data_in + (cropY * m_videoMode.resolutionX + cropX++);
-					*(data_out++) = (*iter) >> 6;
-				}
-				cropY++;
-			}
-			pFrame->stride = m_cropping.width * 2;
-		}
+		};
+
+		typedef LineCopier<USHORT, OniGrayscale16Pixel, IRToGray16PixelCopier, ForwardMover<USHORT> > ForwardLineCopier;
+		typedef RectCopier<USHORT, OniGrayscale16Pixel, IRToGray16PixelCopier, ForwardMover<USHORT>, ForwardMover<USHORT> > ForwardRectCopier;
+		typedef RectCopier<USHORT, OniGrayscale16Pixel, IRToGray16PixelCopier, BackwardMover<USHORT>, ForwardMover<USHORT> > MirrorRectCopier;
+
+		USHORT* in = reinterpret_cast<USHORT*>(LockedRect.pBits);
+		OniGrayscale16Pixel* out = reinterpret_cast<OniGrayscale16Pixel*>(pFrame->data);
+
+		FrameCopier<USHORT, OniGrayscale16Pixel, ForwardLineCopier, ForwardRectCopier, MirrorRectCopier> copyFrame;
+		copyFrame(in, out, pFrame, m_videoMode, m_cropping, m_mirroring);
 	}
 	else if (m_videoMode.pixelFormat == ONI_PIXEL_FORMAT_GRAY8)
 	{
-		unsigned short* data_in = reinterpret_cast<unsigned short*>(LockedRect.pBits);
-		char* data_out = reinterpret_cast<char*>(pFrame->data);
-		if (!m_cropping.enabled)
+		struct IRToGray8PixelCopier
 		{
-			unsigned short* data_in_end = data_in + (m_videoMode.resolutionY * m_videoMode.resolutionX);
-			while (data_in < data_in_end)
+			void operator()(const USHORT* const in, OniGrayscale8Pixel* const out)
 			{
-				char intensity = (*data_in)>> 8;
-				(*data_out) = intensity;
-				++data_in;
-				++data_out;
+				*out = (*in) >> 8;
 			}
-			pFrame->stride = m_videoMode.resolutionX;
-		}
-		else
-		{
-			int cropY = m_cropping.originY;
-			while (cropY < m_cropping.originY + m_cropping.height)
-			{
-				int cropX = m_cropping.originX;
-				while (cropX < m_cropping.originX + m_cropping.width)
-				{
-					unsigned short *iter = data_in + (cropY * m_videoMode.resolutionX + cropX++);
-					char intensity = (*iter) >> 8;
-					*(data_out++) = intensity;
-				}
-				cropY++;
-			}
-			pFrame->stride = m_cropping.width * 2;
+		};
 
-		}
+		typedef LineCopier<USHORT, OniGrayscale8Pixel, IRToGray8PixelCopier, ForwardMover<USHORT> > ForwardLineCopier;
+		typedef RectCopier<USHORT, OniGrayscale8Pixel, IRToGray8PixelCopier, ForwardMover<USHORT>, ForwardMover<USHORT> > ForwardRectCopier;
+		typedef RectCopier<USHORT, OniGrayscale8Pixel, IRToGray8PixelCopier, BackwardMover<USHORT>, ForwardMover<USHORT> > MirrorRectCopier;
+
+		USHORT* in = reinterpret_cast<USHORT*>(LockedRect.pBits);
+		OniGrayscale8Pixel* out = reinterpret_cast<OniGrayscale8Pixel*>(pFrame->data);
+
+		FrameCopier<USHORT, OniGrayscale8Pixel, ForwardLineCopier, ForwardRectCopier, MirrorRectCopier> copyFrame;
+		copyFrame(in, out, pFrame, m_videoMode, m_cropping, m_mirroring);
+	}
+	else if (m_videoMode.pixelFormat == ONI_PIXEL_FORMAT_RGB888)
+	{
+		struct IRToRgbPixelCopier
+		{
+			void operator()(const USHORT* const in, OniRGB888Pixel* const out)
+			{
+				BYTE intensity = (*in) >> 8;
+				out->r = intensity;
+				out->g = intensity;
+				out->b = intensity;
+			}
+		};
+
+		typedef LineCopier<USHORT, OniRGB888Pixel, IRToRgbPixelCopier, ForwardMover<USHORT> > ForwardLineCopier;
+		typedef RectCopier<USHORT, OniRGB888Pixel, IRToRgbPixelCopier, ForwardMover<USHORT>, ForwardMover<USHORT> > ForwardRectCopier;
+		typedef RectCopier<USHORT, OniRGB888Pixel, IRToRgbPixelCopier, BackwardMover<USHORT>, ForwardMover<USHORT> > MirrorRectCopier;
+
+		USHORT* in = reinterpret_cast<USHORT*>(LockedRect.pBits);
+		OniRGB888Pixel* out = reinterpret_cast<OniRGB888Pixel*>(pFrame->data);
+
+		FrameCopier<USHORT, OniRGB888Pixel, ForwardLineCopier, ForwardRectCopier, MirrorRectCopier> copyFrame;
+		copyFrame(in, out, pFrame, m_videoMode, m_cropping, m_mirroring);
 	}
 	else
 	{
-		struct Rgb { unsigned char r, g, b;    };
-		unsigned short* data_in = reinterpret_cast<unsigned short*>(LockedRect.pBits);
-		Rgb* data_out = reinterpret_cast<Rgb*>(pFrame->data);
-		if (!m_cropping.enabled)
-		{
-			unsigned short* data_in_end = data_in + (m_videoMode.resolutionY * m_videoMode.resolutionX);
-			while (data_in < data_in_end)
-			{
-				char intensity = (*data_in)>> 8;
-				data_out->b = intensity;
-				data_out->r = intensity;
-				data_out->g = intensity;
-				++data_in;
-				++data_out;
-			}
-			pFrame->stride = m_videoMode.resolutionX * 3;
-		}
-		else
-		{
-			int cropY = m_cropping.originY;
-			while (cropY < m_cropping.originY + m_cropping.height)
-			{
-				int cropX = m_cropping.originX;
-				while (cropX < m_cropping.originX + m_cropping.width)
-				{
-					unsigned short *iter = data_in + (cropY * m_videoMode.resolutionX + cropX++);
-					char intensity = (*iter) >> 8;
-					data_out->b = intensity;
-					data_out->r = intensity;
-					data_out++->g = intensity;
-				}
-				cropY++;
-			}
-			pFrame->stride = m_cropping.width * 3;
-		}
+		XN_ASSERT(FALSE); // unsupported format. should not come here.
 	}
 		
 	if (!m_cropping.enabled)

--- a/Source/Drivers/Kinect/KinectDevice.cpp
+++ b/Source/Drivers/Kinect/KinectDevice.cpp
@@ -1,10 +1,10 @@
 #include "KinectDevice.h"
+#include "KinectProperties.h"
 #include "DepthKinectStream.h"
 #include "ColorKinectStream.h"
 #include "IRKinectStream.h"
 #include <Shlobj.h>
 #include "NuiApi.h"
-#include "XnLog.h"
 
 using namespace kinect_device;
 using namespace oni::driver;
@@ -133,14 +133,27 @@ OniStatus KinectDevice::setProperty(int propertyId, const void* data, int dataSi
 	switch (propertyId) {
 	case ONI_DEVICE_PROPERTY_IMAGE_REGISTRATION:
 		{
-			// FIXME data size validation
+			EXACT_PROP_SIZE_OR_RETURN(dataSize, OniImageRegistrationMode);
 			if (m_pDepthStream) {
 				OniImageRegistrationMode* pMode = (OniImageRegistrationMode*)data;
 				m_pDepthStream->setImageRegistrationMode(*pMode);
 				return ONI_STATUS_OK;
-			} else {
+			}
+			else
+			{
 				return ONI_STATUS_ERROR;
 			}
+		}
+	case KINECT_DEVICE_PROPERTY_CAMERA_ELEVATION:
+		{
+			EXACT_PROP_SIZE_OR_RETURN(dataSize, long);
+			return SUCCEEDED(m_pNuiSensor->NuiCameraElevationSetAngle(*(long*)data)) ? ONI_STATUS_OK : ONI_STATUS_ERROR;
+		}
+	case KINECT_DEVICE_PROPERTY_EMITTER_STATE:
+		{
+			EXACT_PROP_SIZE_OR_RETURN(dataSize, OniBool);
+			OniBool b = *(OniBool*)data;
+			return SUCCEEDED(m_pNuiSensor->NuiSetForceInfraredEmitterOff(!b)) ? ONI_STATUS_OK : ONI_STATUS_ERROR;
 		}
 	}
 
@@ -152,13 +165,63 @@ OniStatus KinectDevice::getProperty(int propertyId, void* data, int* pDataSize)
 	switch (propertyId) {
 	case ONI_DEVICE_PROPERTY_IMAGE_REGISTRATION:
 		{
-			// FIXME data size validation
-			if (m_pDepthStream) {
+			EXACT_PROP_SIZE_OR_RETURN(*pDataSize, OniImageRegistrationMode);
+			if (m_pDepthStream)
+			{
 				OniImageRegistrationMode* pMode = (OniImageRegistrationMode*)data;
 				*pMode = m_pDepthStream->getImageRegistrationMode();
 				return ONI_STATUS_OK;
-			} else {
+			}
+			else
+			{
 				return ONI_STATUS_ERROR;
+			}
+		}
+	case KINECT_DEVICE_PROPERTY_CAMERA_ELEVATION:
+		{
+			EXACT_PROP_SIZE_OR_RETURN(*pDataSize, long);
+			return SUCCEEDED(m_pNuiSensor->NuiCameraElevationGetAngle((long*)data)) ? ONI_STATUS_OK : ONI_STATUS_ERROR;
+		}
+	case KINECT_DEVICE_PROPERTY_ACCELEROMETER:
+		{
+			EXACT_PROP_SIZE_OR_RETURN(*pDataSize, KinectVector3f);
+			Vector4 v;
+			if (SUCCEEDED(m_pNuiSensor->NuiAccelerometerGetCurrentReading(&v)))
+			{
+				KinectVector3f* pVector3f = (KinectVector3f*)(data);
+				pVector3f->x = v.x;
+				pVector3f->y = v.y;
+				pVector3f->z = v.z;
+				return ONI_STATUS_OK;
+			}
+			else
+			{
+				return ONI_STATUS_ERROR;
+			}
+		}
+	case KINECT_DEVICE_PROPERTY_EMITTER_STATE:
+		{
+			EXACT_PROP_SIZE_OR_RETURN(*pDataSize, OniBool);
+			*(OniBool*)data = !m_pNuiSensor->NuiGetForceInfraredEmitterOff();
+			return ONI_STATUS_OK;
+		}
+	case KINECT_DEVICE_PROPERTY_AUDIO_ARRAY_ID:
+		{
+			char* arrayId = (char*)data;
+			BSTR wcsArrayId = m_pNuiSensor->NuiAudioArrayId();
+			size_t len = wcstombs(arrayId, wcsArrayId, *pDataSize - 1);
+			SysFreeString(wcsArrayId);
+
+			if (len == -1)
+			{
+				*pDataSize = 0;
+				return ONI_STATUS_ERROR;
+			}
+			else
+			{
+				arrayId[len] = '\0';
+				*pDataSize = int(len + 1);
+				return ONI_STATUS_OK;
 			}
 		}
 	}
@@ -168,7 +231,16 @@ OniStatus KinectDevice::getProperty(int propertyId, void* data, int* pDataSize)
 
 OniBool KinectDevice::isPropertySupported(int propertyId)
 {
-	return (propertyId == ONI_DEVICE_PROPERTY_IMAGE_REGISTRATION);
+	switch (propertyId)
+	{
+	case ONI_DEVICE_PROPERTY_IMAGE_REGISTRATION:
+	case KINECT_DEVICE_PROPERTY_CAMERA_ELEVATION:
+	case KINECT_DEVICE_PROPERTY_ACCELEROMETER:
+	case KINECT_DEVICE_PROPERTY_EMITTER_STATE:
+	case KINECT_DEVICE_PROPERTY_AUDIO_ARRAY_ID:
+		return true;
+	}
+	return false;
 }
 
 OniBool KinectDevice::isCommandSupported(int commandId)

--- a/Source/Drivers/Kinect/KinectStreamImpl.h
+++ b/Source/Drivers/Kinect/KinectStreamImpl.h
@@ -5,6 +5,7 @@
 #include <Shlobj.h>
 #include "NuiApi.h"
 #include "XnList.h"
+#include "XnArray.h"
 
 struct INuiSensor;
 
@@ -51,10 +52,9 @@ public:
 	OniStatus convertDepthToColorCoordinates(oni::driver::StreamBase* colorStream, 
 								int depthX, int depthY, OniDepthPixel depthZ, int* pColorX, int* pColorY);
 
-	static NUI_IMAGE_RESOLUTION getNuiImagResolution(int resolutionX, int resolutionY);
+	OniStatus convertDepthFrameToColorCoordinates(const OniVideoMode& colorVideoMode,
+								const NUI_DEPTH_IMAGE_PIXEL* depthPixels, int numPoints, int* colorXYs);
 
-	INuiSensor* getNuiSensor() { return m_pNuiSensor; } // Need review: not sure if it is a good idea to expose this.
-	
 private:
 		
 	void setDefaultVideoMode();
@@ -63,6 +63,8 @@ private:
 
 	static XN_THREAD_PROC threadFunc(XN_THREAD_PARAM pThreadParam);
 
+	static NUI_IMAGE_RESOLUTION getNuiImageResolution(int resolutionX, int resolutionY);
+	
 	xnl::List<BaseKinectStream*> m_streamList;
 
 	OniImageRegistrationMode m_imageRegistrationMode;
@@ -76,6 +78,18 @@ private:
 	OniVideoMode m_videoMode;
 	
 	XN_THREAD_HANDLE m_threadHandle;	
+
+	// Helper class to depth frame to image coordinate conversion
+	class DepthToImageCoordsConverter
+	{
+	public:
+		DepthToImageCoordsConverter(INuiSensor* pNuiSensor);
+		OniStatus convert(const OniVideoMode& depthVideoMode, const OniVideoMode& colorVideoMode, const NUI_DEPTH_IMAGE_PIXEL* depthPixels, int numPoints, int* colorXYs);
+
+	private:
+		INuiSensor* m_pNuiSensor;
+		xnl::Array<USHORT> m_depthValuesBuffer; // temporary buffer for depth values shifted by 3 bits
+	} m_depthToImageCoordsConverter;
 };
 
 //

--- a/Source/Drivers/Kinect/KinectStreamImpl.h
+++ b/Source/Drivers/Kinect/KinectStreamImpl.h
@@ -77,6 +77,110 @@ private:
 	
 	XN_THREAD_HANDLE m_threadHandle;	
 };
+
+//
+// Helper templates for frame copy
+//
+
+// This is the most standard pixel copy implementation.
+// You can create your own pixel copy implementation if any conversion is necessary.
+template<typename SourceType, typename DestType>
+struct PixelCopier
+{
+	void operator()(const SourceType* const in, DestType* const out)
+	{
+		*out = *in;
+	}
+};
+
+template<typename SourceType, typename DestType, typename PixelCopier, typename SourceMover>
+struct LineCopier
+{
+	void operator()(const SourceType* in, DestType* out, const int count)
+	{
+		PixelCopier copyPixel;
+		SourceMover moveSource;
+		const SourceType* end = moveSource(in, count);
+		while (in != end) {
+			copyPixel(in, out);
+			in = moveSource(in, 1);
+			++out;
+		}
+	}
+};
+
+template<typename SourceType, typename DestType, typename PixelCopier, typename HorizontalSourceMover, typename VerticalSourceMover>
+struct RectCopier
+{
+	void operator()(const SourceType* in, DestType* out, const int copyWidth, const int totalWidth, const int copyHeight)
+	{
+		LineCopier<SourceType, DestType, PixelCopier, HorizontalSourceMover> copyLine;
+		VerticalSourceMover moveSource;
+		const SourceType* end = moveSource(in, totalWidth * copyHeight);
+		while (in != end) {
+			copyLine(in, out, copyWidth);
+			in = moveSource(in, totalWidth);
+			out += copyWidth;
+		}
+	}
+};
+
+template<typename T>
+struct ForwardMover {
+	T* operator()(T* const p, const int offset) { return p+offset; }
+	const T* operator()(const T* const p, const int offset) { return p+offset; }
+};
+
+template <typename T>
+struct BackwardMover {
+	T* operator()(T* const p, const int offset) { return p-offset; }
+	const T* operator()(const T* const p, const int offset) { return p-offset; }
+};
+
+template<typename SourceType, typename DestType, typename ForwardLineCopier, typename ForwardRectCopier, typename MirrorRectCopier>
+struct FrameCopier {
+	void operator()(const SourceType* in, DestType* out, OniFrame* pFrame, const OniVideoMode& videoMode, const OniCropping& cropping, OniBool mirroring)
+	{
+		const int resX = videoMode.resolutionX;
+		const int resY = videoMode.resolutionY;
+
+		if (!cropping.enabled)
+		{
+			const int pixelCount = resX * resY;
+			pFrame->dataSize = pixelCount * sizeof(DestType);
+			pFrame->stride = resX * sizeof(DestType);
+
+			if (!mirroring)
+			{
+				ForwardLineCopier copyLine;
+				copyLine(in, out, pixelCount);
+			} else {
+				MirrorRectCopier copyRect;
+				copyRect(in+resX-1, out, resX, resX, resY);
+			}
+		}
+		else
+		{
+			const int pixelCount = cropping.height * cropping.width;
+			pFrame->dataSize = pixelCount * sizeof(DestType);
+			pFrame->stride = cropping.width * sizeof(DestType);
+
+			if (!mirroring)
+			{
+				ForwardRectCopier copyRect;
+				const SourceType* origin = in + cropping.originY * resX + cropping.originX;
+				copyRect(origin, out, cropping.width, resX, cropping.height);
+			}
+			else
+			{
+				MirrorRectCopier copyRect;
+				const SourceType* origin = in + (cropping.originY+1) * resX - cropping.originX - 1;
+				copyRect(origin, out, cropping.width, resX, cropping.height);
+			}
+		}
+	}
+};
+
 } // namespace kinect_device
 
 #endif //_KINECT_STREAM_IMPL_H_

--- a/Source/Drivers/Kinect/KinectStreamImpl.h
+++ b/Source/Drivers/Kinect/KinectStreamImpl.h
@@ -55,11 +55,21 @@ public:
 	OniStatus convertDepthFrameToColorCoordinates(const OniVideoMode& colorVideoMode,
 								const NUI_DEPTH_IMAGE_PIXEL* depthPixels, int numPoints, int* colorXYs);
 
+	DWORD getImageFrameFlags();
+
+	OniBool getImageFrameFlags(DWORD mask) { return (getImageFrameFlags() & mask) != 0; }
+
+	OniStatus setImageFrameFlags(DWORD value);
+
+	OniStatus setImageFrameFlags(DWORD mask, OniBool value);
+
 private:
 		
 	void setDefaultVideoMode();
 	
 	NUI_IMAGE_TYPE getNuiImageType();
+
+	OniStatus pushImageFrameFlags();
 
 	static XN_THREAD_PROC threadFunc(XN_THREAD_PARAM pThreadParam);
 
@@ -68,6 +78,8 @@ private:
 	xnl::List<BaseKinectStream*> m_streamList;
 
 	OniImageRegistrationMode m_imageRegistrationMode;
+
+	DWORD m_imageFrameFlags;
 
 	// Thread
 	INuiSensor* m_pNuiSensor;

--- a/Source/Drivers/PS1080/DDK/XnDeviceModule.cpp
+++ b/Source/Drivers/PS1080/DDK/XnDeviceModule.cpp
@@ -231,7 +231,7 @@ XnStatus XnDeviceModule::GetProperty(XnUInt32 propertyId, void* data, int* pData
 			nRetVal = GetProperty(propertyId, &nValue);
 			if (nRetVal != XN_STATUS_OK)
 			{
-				XN_ASSERT(FALSE);
+				// XN_ASSERT(FALSE); // This could happen when the property was write only
 				return XN_STATUS_ERROR;
 			}
 

--- a/Source/Tools/NiViewer/Device.cpp
+++ b/Source/Tools/NiViewer/Device.cpp
@@ -27,6 +27,7 @@
 #include <math.h>
 #include <XnLog.h>
 #include <PS1080.h>
+#include <KinectProperties.h>
 
 // --------------------------------
 // Defines
@@ -364,14 +365,46 @@ void toggleMirror(int )
 
 void toggleCloseRange(int )
 {
-	bool bCloseRange;
-	g_depthStream.getProperty(XN_STREAM_PROPERTY_CLOSE_RANGE, &bCloseRange);
+	static OniBool bCloseRange = FALSE;
+
+	if (g_depthStream.getProperty(XN_STREAM_PROPERTY_CLOSE_RANGE, &bCloseRange) != XN_STATUS_OK &&
+		g_depthStream.getProperty(KINECT_DEPTH_PROPERTY_CLOSE_RANGE, &bCloseRange) != XN_STATUS_OK)
+	{
+		// Continue with the latest value even in case of error
+	}
 
 	bCloseRange = !bCloseRange;
 
-	g_depthStream.setProperty(XN_STREAM_PROPERTY_CLOSE_RANGE, bCloseRange);
+	if (g_depthStream.setProperty(XN_STREAM_PROPERTY_CLOSE_RANGE, bCloseRange) != XN_STATUS_OK &&
+		g_depthStream.setProperty(KINECT_DEPTH_PROPERTY_CLOSE_RANGE, bCloseRange) != XN_STATUS_OK)
+	{
+		displayError("Couldn't set the close range");
+		return;
+	}
 
 	displayMessage ("Close range: %s", bCloseRange?"On":"Off");	
+}
+
+void toggleEmitterState(int)
+{
+	static OniBool bEmitterState = TRUE;
+
+	if (g_device.getProperty(XN_MODULE_PROPERTY_EMITTER_STATE, &bEmitterState) != XN_STATUS_OK &&
+		g_device.getProperty(KINECT_DEVICE_PROPERTY_EMITTER_STATE, &bEmitterState) != XN_STATUS_OK)
+	{
+		// Continue with the latest value even in case of error
+	}
+
+	bEmitterState = !bEmitterState;
+
+	if (g_device.setProperty(XN_MODULE_PROPERTY_EMITTER_STATE, bEmitterState) != XN_STATUS_OK &&
+		g_device.setProperty(KINECT_DEVICE_PROPERTY_EMITTER_STATE, bEmitterState) != XN_STATUS_OK)
+	{
+		displayError("Couldn't set the emitter state");
+		return;
+	}
+
+	displayMessage ("Emitter state: %s", bEmitterState?"On":"Off");	
 }
 
 void toggleImageRegistration(int)

--- a/Source/Tools/NiViewer/Device.h
+++ b/Source/Tools/NiViewer/Device.h
@@ -112,6 +112,7 @@ void changeImageExposure(int);
 void changeImageGain(int);
 
 void toggleCloseRange(int);
+void toggleEmitterState(int);
 void toggleImageRegistration(int);
 
 void setStreamCropping(openni::VideoStream& stream, int originX, int originY, int width, int height);

--- a/Source/Tools/NiViewer/NiViewer.cpp
+++ b/Source/Tools/NiViewer/NiViewer.cpp
@@ -305,15 +305,16 @@ void createKeyboardMap()
  			registerKey('m', "Mirror on/off", toggleMirror, 0);
  			registerKey('/', "Reset all croppings", resetAllCropping, 0);
 
-			registerKey('a', "toggle Auto Exposure", toggleImageAutoExposure, 0);
-			registerKey('q', "toggle AWB", toggleImageAutoWhiteBalance, 0);
+			registerKey('a', "Toggle Auto Exposure", toggleImageAutoExposure, 0);
+			registerKey('q', "Toggle AWB", toggleImageAutoWhiteBalance, 0);
 			registerKey('e', "Increase Exposure", changeImageExposure, 1);
 			registerKey('E', "Decrease Exposure", changeImageExposure, -1);
 			registerKey('g', "Increase Gain", changeImageGain, 10);
 			registerKey('G', "Decrease Gain", changeImageGain, -10);
 
-			registerKey('x', "Close Range", toggleCloseRange, 0);
+			registerKey('x', "Toggle Close Range", toggleCloseRange, 0);
 			registerKey('i', "Toggle Image Registration", toggleImageRegistration, 0);
+			registerKey('t', "IR Emitter on/off", toggleEmitterState, 0);
  		}
  		endKeyboardGroup();
  		startKeyboardGroup(KEYBOARD_GROUP_CAPTURE);


### PR DESCRIPTION
This patch includes exactly the same changes in #32 plus extended properties for Kinect Driver. The only addition to #32 is commit 20eb30f and below is the description.
- Supported properties
  - 3D sensing properties: Near Mode, IR Emitter On/Off
  - Non- 3D sensing properties: Camera Elevation, Accelerometer, Audio Array ID
- API header KinectProperties.h is added. This is a sibling of other private property headers
  such as PrimeSense.h, PS1080.h, etc.
  (Suffix "Properties" is included in the file name for more clarity.)
- The first 4 hex digits of these properties are 0x045e, taken from Microsoft's USB vendor ID.
- NiViewer's toggleCloseRange now supports Kinect using these properties.
- IR emitter on/off is added ('t' key) to NiViewer for both PS1080 and Kinect.
- Design notes
  - I struggled if I should reuse the properties of the same meanings in PS1080.h
    (i.e. XN_STREAM_PROPERTY_CLOSE_RANGE and XN_MODULE_PROPERTY_EMITTER_STATE).
    The confusion was, although PS1080.h seemed to be private for PS1080 Driver,
    it was included and used in Kinect Driver also (e.g. XN_STREAM_PROPERTY_CONST_SHIFT).
    I eventually decided not to reuse them assuming PS1080.h was actually supposed to be
    private, and its use in Kinect Driver was a "hidden hack" to make NiTE work.
    If my reading was wrong, please let me know. I will be more than happy to fix.
  - Or, do we want to "promote" these properties (i.e. CLOSE_RANGE and EMITTER_STATE)
    as a member of ONI properties? It may not be a bad idea.
  - Passing a bool type value to setProperty for an OniBool type property may fail
    because bool and OniBool are actually different in size (1 byte vs. 4 bytes).
    You can workaround this issue by explicitly specifying the data type like
    setProperty<OniBool>(). For the same reason, you cannot get an OniBool type
    property into a bool type variable.
    (This is confusing and hope we can improve this in the future.)
  - Fixed a bug in XnDeviceModule.cpp that caused a crash when reading
    XN_MODULE_PROPERTY_EMITTER_STATE from a PS1080 device, which I found
    while enhancing NiViewer.

Thanks again to KHeresy who created #22 which I used as a reference.
