### PR TITLE
Fixes for compiling under OSX 10.8 with clang

### DIFF
--- a/Source/Drivers/PS1080/DDK/XnPixelStream.h
+++ b/Source/Drivers/PS1080/DDK/XnPixelStream.h
@@ -132,6 +132,7 @@ private:
 	XnGeneralProperty m_SupportedModes;
 
 	xnl::Array<XnCmosPreset> m_supportedModesData;
+protected:
 	XnBool m_bAllowCustomResolutions;
 };
 

--- a/Source/Drivers/PS1080/Sensor/XnDeviceSensorIO.h
+++ b/Source/Drivers/PS1080/Sensor/XnDeviceSensorIO.h
@@ -93,8 +93,8 @@ private:
 	XnBool m_bMiscSupported;
 	XnChar m_strDeviceName[XN_DEVICE_MAX_STRING_LENGTH];
 	XnBool m_bIsLowBandwidth;
-	XnUSBEventCallbackFunctionPtr m_pCallbackPtr; 
-	void* m_pCallbackData;
+	//XnUSBEventCallbackFunctionPtr m_pCallbackPtr; //private field is not used, clashes with clang due to [-Werror,-Wunused-private-field]
+	//void* m_pCallbackData; //private field is not used, clashes with clang due to [-Werror,-Wunused-private-field]
 };
 
 #endif //__XN_DEVICE_SENSOR_I_O_H__

--- a/Source/Drivers/PSLink/LinkProtoLib/XnClientUSBConnectionFactory.h
+++ b/Source/Drivers/PSLink/LinkProtoLib/XnClientUSBConnectionFactory.h
@@ -41,7 +41,9 @@ public:
 private:
 	XnUInt16 m_nInputConnections;
 	XnUInt16 m_nOutputConnections;
-	XnUInt32 m_nPreControlReceiveSleep;
+protected:
+	XnUInt32 m_nPreControlReceiveSleep; //if private and field not used, it clashes with clang due to [-Werror,-Wunused-private-field]
+private:
 	XnUInt8 m_nAltInterface;
 
 	ClientUSBControlEndpoint m_controlEndpoint;

--- a/Source/Drivers/PSLink/LinkProtoLib/XnLink6BitParser.h
+++ b/Source/Drivers/PSLink/LinkProtoLib/XnLink6BitParser.h
@@ -21,7 +21,8 @@ protected:
 
 private:
 	XnUInt32 m_nState;
-	XnUInt16 m_nShift;
+protected:
+	XnUInt16 m_nShift; //if private and field not used, it clashes with clang due to [-Werror,-Wunused-private-field]
 };
 
 }

--- a/Source/Drivers/PSLink/PrimeClient.h
+++ b/Source/Drivers/PSLink/PrimeClient.h
@@ -111,7 +111,7 @@ private:
 	XnBool m_bInitialized;
     volatile XnBool m_bConnected;
 	xnl::Array<LinkInputDataEndpoint> m_inputDataEndpoints;
-	XnBool m_bAnyDataEndpointConnected;
+	//XnBool m_bAnyDataEndpointConnected; //private field is not used, clashes with clang due to [-Werror,-Wunused-private-field]
     XnUInt16 m_nFWLogStreamID;
 	XnChar m_strConnectionString[XN_FILE_MAX_PATH];
 


### PR DESCRIPTION
Hi,

Some private fields in OpenNI2 classes are colliding with Apple LLVM version 4.2 (clang-425.0.28) (based on LLVM 3.2svn) that uses -Werror,-Wunused-private-field. So as to make OpenNI2 compile, it did 2 kinds of hacks:
- promoting from private to protected
- commenting out the unused private class members.

I don't know about the OpenNI2 architecture, hence the hacks. Could you please review these?

Best regards,
Christian
