### PR TITLE
Updates __android_log_print usage to NDK r9

### DIFF
--- a/ThirdParty/PSCommon/XnLib/Source/XnLogAndroidWriter.cpp
+++ b/ThirdParty/PSCommon/XnLib/Source/XnLogAndroidWriter.cpp
@@ -58,7 +58,7 @@ void XnLogAndroidWriter::WriteEntry(const XnLogEntry* pEntry)
 #ifdef XN_PLATFORM_ANDROID_OS
 	ALOGE("OpenNI2: %s\n", pEntry->strMessage);
 #else
-	__android_log_print(OpenNISeverityToAndroid(pEntry->nSeverity), "OpenNI", pEntry->strMessage);
+	__android_log_print(OpenNISeverityToAndroid(pEntry->nSeverity), "OpenNI", "OpenNI2: %s\n", pEntry->strMessage);
 #endif
 }
 


### PR DESCRIPTION
I found that I had to do this small update to get OpenNI2 to compile for Android NDK r9.

Not sure this is exactly the right way to go about this fix, but perhaps it can inspire someone to do the right thing. 
