### PR TITLE
Don't attempt opening devices if none are connected

### DIFF
--- a/Samples/SimpleViewer.Android/src/org/openni/android/samples/simpleviewer/SimpleViewerActivity.java
+++ b/Samples/SimpleViewer.Android/src/org/openni/android/samples/simpleviewer/SimpleViewerActivity.java
@@ -75,11 +75,12 @@ public class SimpleViewerActivity
 		List<DeviceInfo> devices = OpenNI.enumerateDevices();
 		if (devices.isEmpty()) {
 			showAlertAndExit("No OpenNI-compliant device found.");
-		}
-		uri = devices.get(0).getUri();
-		
-		mDeviceOpenPending = true;
-		mOpenNIHelper.requestDeviceOpen(uri, this);
+		} else {
+      uri = devices.get(0).getUri();
+
+      mDeviceOpenPending = true;
+      mOpenNIHelper.requestDeviceOpen(uri, this);
+    }
 	}
 
 	private void showAlertAndExit(String message) {


### PR DESCRIPTION
Fixes a small issue that makes the sample app crash if started without any connected openni devices.
This is because showAlertAndExit is executed asynchronously, execution continues past the "if" even when it evaluates to true.
