### PR TITLE
libc++ compliance fix

### DIFF
--- a/ThirdParty/GL/glh/glh_convenience.h
+++ b/ThirdParty/GL/glh/glh_convenience.h
@@ -47,12 +47,6 @@
 // with opengl...
 
 
-
-// debugging hack...
-#include <iostream>
-
-using namespace std;
-
 #ifdef MACOS
 #include <OpenGL/gl.h>
 #else


### PR DESCRIPTION
Fixes compilation in OSX 10.9 and it can be linked to libc++ instead.
