### PR TITLE
Fix compilation error due to the use of i386 in C++11

### DIFF
--- a/Include/OniPlatform.h
+++ b/Include/OniPlatform.h
@@ -37,7 +37,7 @@
 #	include "Win32/OniPlatformWin32.h"
 #elif defined (ANDROID) && defined (__arm__)
 #	include "Android-Arm/OniPlatformAndroid-Arm.h"
-#elif (__linux__ && (i386 || __x86_64__))
+#elif (__linux__ && (__i386__ || __x86_64__))
 #	include "Linux-x86/OniPlatformLinux-x86.h"
 #elif (__linux__ && __arm__)
 #	include "Linux-Arm/OniPlatformLinux-Arm.h"

--- a/Source/Tools/NiViewer/Makefile
+++ b/Source/Tools/NiViewer/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 LIB_DIRS  += ../../../ThirdParty/PSCommon/XnLib/Bin/$(PLATFORM)-$(CFG)
-USED_LIBS += OpenNI2 XnLib
+USED_LIBS += OpenNI2 XnLib pthread
 
 EXE_NAME = NiViewer
 

--- a/ThirdParty/LibJPEG/jconfig.h
+++ b/ThirdParty/LibJPEG/jconfig.h
@@ -4,7 +4,7 @@
 #elif SN_TARGET_PS3
 	#include "jconfig.ps3"
 	#include <stdio.h>
-#elif ((linux) || (__APPLE__))
+#elif ((__linux__) || (__APPLE__))
 	#include "jconfig.lnx86"
 	#include <stdio.h>
 #else


### PR DESCRIPTION
I got an issue due to OpenNI2 when compiling my project in C++11 mode, apparently `i386` is no longer defined by GCC in C++11 mode (at least with gcc 4.6 -std=c++0x), I made use of `__i386__` is used instead.
