### PR TITLE
Fix kinect recording oni for NiTE 2.2

### DIFF
--- a/Source/Drivers/Kinect/DepthKinectStream.cpp
+++ b/Source/Drivers/Kinect/DepthKinectStream.cpp
@@ -442,6 +442,10 @@ void DepthKinectStream::notifyAllProperties()
 	getProperty(XN_STREAM_PROPERTY_D2S_TABLE, nBuff, &size);
 	raisePropertyChanged(XN_STREAM_PROPERTY_D2S_TABLE, nBuff, size);
 
+	size = sizeof(PARAM_COEFF_VAL);
+	getProperty(XN_STREAM_PROPERTY_PARAM_COEFF, nBuff, &size);
+	raisePropertyChanged(XN_STREAM_PROPERTY_PARAM_COEFF, nBuff, size);
+
 	// Is this really necessary to save? Just in case.
 	OniBool nearMode;
 	size = sizeof(nearMode);


### PR DESCRIPTION
The ONI file recorded from Kinect sensor can't work with NiTE 2.2 because leak the property XN_STREAM_PROPERTY_PARAM_COEFF.

This patch fix this issue.
